### PR TITLE
Create macos_space_after_filename.yml

### DIFF
--- a/rules/linux/macos/process_creation/macos_space_after_filename.yml
+++ b/rules/linux/macos/process_creation/macos_space_after_filename.yml
@@ -3,7 +3,7 @@ id: b6e2a2e3-2d30-43b1-a4ea-071e36595690
 status: experimental
 description: Detects attempts to masquerade as legitimate files by adding a space to the end of the filename.
 author: remotephone
-date: 2020/10/13
+date: 2021/11/20
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1036.006/T1036.006.md
 logsource:

--- a/rules/linux/macos/process_creation/macos_space_after_filename.yml
+++ b/rules/linux/macos/process_creation/macos_space_after_filename.yml
@@ -1,0 +1,23 @@
+title: Space After Filename - macOS
+id: b6e2a2e3-2d30-43b1-a4ea-071e36595690
+status: experimental
+description: Detects attempts to masquerade as legitimate files by adding a space to the end of the filename.
+author: remotephone
+date: 2020/10/13
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1036.006/T1036.006.md
+logsource:
+    product: macos
+    category: process_creation
+detection:
+    selection1:
+        CommandLine|endswith: ' '
+    selection2:
+        ImageName|endswith: ' '
+    condition: selection1 or selection2
+falsepositives:
+    - Mistyped commands or legitimate binaries named to match the pattern
+level: low
+tags:
+    - attack.defense_evasion
+    - attack.t1036.006


### PR DESCRIPTION
Picking up the work here https://github.com/SigmaHQ/sigma/issues/1012 to contribute a single rule for detecting files or commands run with a space at the end to masquerade as legit files. 

See https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1036.006/T1036.006.md

This rule does not work on the carbonblack backend, but this appears to be an issue with the converter and not the rule itself as elasticsearch es-qs conversion works fine. I'll open a separate issue for that. 


```
(sigma) ┌─(~/sigma)────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────(redacted@redacted:s005)─┐
└─(15:28:58 on T1036.006_space_after_filename_macos ✹ ✭)──> tools/sigmac --target carbonblack ./rules/linux/macos/process_creation/macos_space_after_filename.yml -c carbon-black 

```